### PR TITLE
bugfix: lightbox broken when context changed

### DIFF
--- a/src/sap.m/src/sap/m/LightBoxItem.js
+++ b/src/sap.m/src/sap/m/LightBoxItem.js
@@ -164,7 +164,7 @@ sap.ui.define([
 
             this._imageState = LightBoxLoadingStates.Loading;
 
-            if (oLightBox && oLightBox._oPopup.getOpenState() === OpenState.OPEN) {
+            if (oLightBox && oLightBox._oPopup.getOpenState() !== OpenState.OPEN) {
                 this._oImage.src = sImageSrc;
             }
 


### PR DESCRIPTION
image get not displayed after popup has been opened, when image src of a lightbox instance changed.