### PR TITLE
[FIX] sap.m.LightBoxItem: image not displayed when context changed

### DIFF
--- a/src/sap.m/src/sap/m/LightBoxItem.js
+++ b/src/sap.m/src/sap/m/LightBoxItem.js
@@ -164,7 +164,7 @@ sap.ui.define([
 
             this._imageState = LightBoxLoadingStates.Loading;
 
-            if (oLightBox && oLightBox._oPopup.getOpenState() === OpenState.OPEN) {
+            if (oLightBox && oLightBox._oPopup.getOpenState() !== OpenState.OPEN) {
                 this._oImage.src = sImageSrc;
             }
 


### PR DESCRIPTION
- Image did not get displayed once the light box has been opened.
- Image source should be allowed to changed as long as the popup is not opened.

Fixes https://github.com/SAP/openui5/issues/1912